### PR TITLE
Use a faster callstack traversal for get_caller

### DIFF
--- a/mlperf_logging/mllog/mllog.py
+++ b/mlperf_logging/mllog/mllog.py
@@ -53,8 +53,11 @@ def get_caller(stack_index=2, root_dir=None):
       "file": (string) file path
       "lineno": (int) line number
   """
-  caller = inspect.getframeinfo(inspect.stack()[stack_index][0])
-
+  frame = inspect.currentframe()
+  for _ in range(stack_index):
+    frame = frame.f_back
+  caller = inspect.getframeinfo(frame)
+  
   # Trim the filenames for readability.
   filename = caller.filename
   if root_dir is not None:


### PR DESCRIPTION
inspect.stack() can be an extremely expensive function, adding 50ms or more for each call, depending on the stack depth and other factors.  For this potentially time-sensitive setting it's better to use the much faster inspect.currentframe() and manual back-traversal of the python frames.