### PR TITLE
[compliance_checker][minigo] checks update

### DIFF
--- a/mlperf_logging/compliance_checker/0.7.0/minigo.yaml
+++ b/mlperf_logging/compliance_checker/0.7.0/minigo.yaml
@@ -12,7 +12,7 @@
 
 - KEY:
     NAME:  actual_selfplay_games_per_generation
-    REQ:   EXACTLY_ONE
+    REQ:   AT_LEAST_ONE
     CHECK:
       - "v['value'] >= 8192"
 
@@ -34,4 +34,10 @@
 
 - KEY:
     NAME: block_stop
+
+- KEY:
+    NAME: train_samples
+
+- KEY:
+    NAME: eval_samples
 

--- a/mlperf_logging/compliance_checker/mlp_compliance.py
+++ b/mlperf_logging/compliance_checker/mlp_compliance.py
@@ -193,7 +193,6 @@ class ComplianceChecker:
                 at_least_one_checks[line.key] = [0, key_record['ATLEAST_ONE_CHECK']]
               check = eval(key_record['ATLEAST_ONE_CHECK'].strip(),
                            state, {'ll': line, 'v': line.value})
-              print(line, check)
               if check:
                 at_least_one_checks[line.key][0] += 1
         for name in at_least_one_checks:


### PR DESCRIPTION
* MiniGo doesn't have a train dataset, so train samples should not be required. 
* Eval samples are covered by `eval_games`. 
* `actual_selfplay_games_per_generation` should be reported more than once (once per epoch)