### PR TITLE
Fix integer conversion error.

### DIFF
--- a/mlperf_logging/compliance_checker/mlp_compliance.py
+++ b/mlperf_logging/compliance_checker/mlp_compliance.py
@@ -15,7 +15,7 @@ from . import mlp_parser
 
 
 def is_integer(value):
-    return abs(int(value) - value) < 0.00001
+    return abs(round(value) - value) < 0.00001
 
 
 class CCError(Exception): 


### PR DESCRIPTION
We used int() instead of round() resulting in correct "is integer" checking.