### PR TITLE
[compliance_checker][minigo] fixing a typo in the target accuracy check

### DIFF
--- a/mlperf_logging/compliance_checker/0.7.0/minigo.yaml
+++ b/mlperf_logging/compliance_checker/0.7.0/minigo.yaml
@@ -27,7 +27,7 @@
     REQ:   AT_LEAST_ONE
     CHECK:
         - "'epoch_num' in v['metadata']"
-    ATLEAST_ONE_CHECK: "v['value'] >= 0.55 and v['value'] < 1.0"
+    ATLEAST_ONE_CHECK: "v['value'] >= 0.5 and v['value'] < 1.0"
 
 - KEY:
     NAME: block_start


### PR DESCRIPTION
according to
https://github.com/mlperf/training_policies/blob/16302f66575f2afbaa096eba5bdc26b62918fd3f/training_rules.adoc#3-benchmarks
target is 0.5 not 0.55