### PR TITLE
Adjusting package verifier to support convergence dropping.

### DIFF
--- a/mlperf_logging/compliance_checker/mlp_compliance.py
+++ b/mlperf_logging/compliance_checker/mlp_compliance.py
@@ -76,12 +76,13 @@ class ComplianceChecker:
 
     def log_messages(self):
         message_separator = '\n' + '-' * 30 + '\n'
-
-        print(message_separator.join([
-            *self.warnings.values(),
-            *self.overwritable.values(),
-            *self.not_overwritable
-        ]))
+        message = message_separator.join([
+                    *self.warnings.values(),
+                    *self.overwritable.values(),
+                    *self.not_overwritable
+        ])
+        if message:
+          print(message)
 
     def has_messages(self):
         return self.not_overwritable or self.overwritable

--- a/mlperf_logging/package_checker/package_checker.py
+++ b/mlperf_logging/package_checker/package_checker.py
@@ -53,8 +53,7 @@ def check_training_result_files(folder, ruleset, quiet, werror):
         ruleset: The ruleset such as 0.6.0 or 0.7.0.
     """
 
-    errors_found = 0
-
+    too_many_errors = False
     result_folder = os.path.join(folder, 'results')
     for system_folder in _get_sub_folders(result_folder):
         for benchmark_folder in _get_sub_folders(system_folder):
@@ -88,6 +87,7 @@ def check_training_result_files(folder, ruleset, quiet, werror):
                     _EXPECTED_RESULT_FILE_COUNTS[benchmark],
                     len(result_files)))
 
+            errors_found = 0
             result_files.sort()
             for result_file in result_files:
                 result_basename = os.path.basename(result_file)
@@ -107,11 +107,15 @@ def check_training_result_files(folder, ruleset, quiet, werror):
                 valid, _, _, _ = mlp_compliance.main(result_file, config_file, checker)
                 if not valid:
                   errors_found += 1
-
+            if errors_found == 1:
+              print('WARNING: One file does not comply.')
+              print('WARNING: Allowing this failure under olympic scoring rules.')
+            if errors_found > 1:
+              too_many_errors = True
 
             _print_divider_bar()
-    if errors_found > 0:
-      raise Exception('Found errors in logging, see log above for details.')
+    if too_many_errors:
+      raise Exception('Found too many errors in logging, see log above for details.')
 
 
 def check_training_package(folder, ruleset, quiet, werror):

--- a/mlperf_logging/result_summarizer/result_summarizer.py
+++ b/mlperf_logging/result_summarizer/result_summarizer.py
@@ -108,7 +108,7 @@ def _code_url(system_desc, ruleset):
 
 
 def _row_key(system_desc):
-    system_name = system_desc['system_name']
+    system_name = '{}-{}'.format(system_desc['system_name'], system_desc['framework'])
     if system_name == 'tpu-v3':
         chips = int(system_desc['accelerators_per_node']) * 2
         return 'tpu-v3-{:04d}'.format(chips)

--- a/mlperf_logging/result_summarizer/result_summarizer.py
+++ b/mlperf_logging/result_summarizer/result_summarizer.py
@@ -250,7 +250,7 @@ def summarize_results(folder, ruleset):
                 else:
                     scores.append(score)
             if dropped_scores > 1:
-              print('CRITICAL ERROR: Too many non-convnerging runs for {} {}/{}'.
+              print('CRITICAL ERROR: Too many non-converging runs for {} {}/{}'.
                     format(desc['submitter'], system, benchmark))
               print('** CRITICAL ERROR ** Results in the table for {} {}/{} are NOT correct'.
                     format(desc['submitter'], system, benchmark))


### PR DESCRIPTION
Under olympic scoring rules, we are allowed to drop one run which does not converge. This updates the package verifier to allow submitters to submit non-converging runs as long as it following this olympic scoring rule.