### PR TITLE
[package_checker][DLRM] expected DLRM results set to 5

### DIFF
--- a/mlperf_logging/package_checker/package_checker.py
+++ b/mlperf_logging/package_checker/package_checker.py
@@ -23,7 +23,7 @@ _ALLOWED_BENCHMARKS = [
 
 _EXPECTED_RESULT_FILE_COUNTS = {
     'bert': 10,
-    'dlrm': 10,
+    'dlrm': 5,
     'gnmt': 10,
     'maskrcnn': 5,
     'minigo': 10,


### PR DESCRIPTION
according to
https://github.com/mlperf/training_policies/blob/master/training_rules.adoc#11-benchmark-results
package_checker should expect 5 DLRM results, not 10